### PR TITLE
Moved `Ev` from a generic type parameter to a member type in CIPT.

### DIFF
--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -10,6 +10,9 @@ trait SortedSet[A]
 
 trait SortedSetLike[A, +C[X] <: SortedSet[X]]
   extends SortedLike[A, C[A]]
-    with ConstrainedIterablePolyTransforms[A, Set, SortedSet, Ordering]
+    with ConstrainedIterablePolyTransforms[A, Set, SortedSet]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
-    with SetMonoTransforms[A, C[A]] // Override the return type of Set ops to return C[A]
+    with SetMonoTransforms[A, C[A]]// Override the return type of Set ops to return C[A]
+{
+  type Ev[A] = Ordering[A]
+}

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -13,6 +13,7 @@ trait SortedSet[A]
 
 trait SortedSetLike[A, +C[X] <: SortedSet[X]]
   extends collection.SortedSetLike[A, C]
-    with ConstrainedIterablePolyTransforms[A, Set, C, Ordering]
+    with ConstrainedIterablePolyTransforms[A, Set, C]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
     with SetMonoTransforms[A, C[A]] // Override the return type of Set ops to return C[A]
+    

--- a/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -12,6 +12,6 @@ trait SortedSet[A]
 
 trait SortedSetLike[A, +C[X] <: SortedSet[X]]
   extends collection.SortedSetLike[A, C]
-    with ConstrainedIterablePolyTransforms[A, Set, SortedSet, Ordering]
+    with ConstrainedIterablePolyTransforms[A, Set, SortedSet]
     with SetLike[A, Set]
     with SetMonoTransforms[A, C[A]]


### PR DESCRIPTION
This seems like a safe move, and helps simplify the method signatures.  Furthermore, it is DRY since only the supertype of the constrained collections need to specify what the constraint is.